### PR TITLE
Fixes issue #1

### DIFF
--- a/lib/atom-linter-encore.coffee
+++ b/lib/atom-linter-encore.coffee
@@ -48,8 +48,8 @@ module.exports = AtomLinterEncore =
               output += data
             stderr: (data) ->
               atom.notifications.addWarning data
-            exit: ->
-                if output is ''
+            exit: (code) ->
+                if code is 0
                   resolve []
                 else
                   match = output.match(/line ([0-9]+), column ([0-9]+)/)


### PR DESCRIPTION
Check exit status instead of empty output to ensure that the response is correct when `encorec` doesn't report any errors
